### PR TITLE
이선로/1주차/금요일

### DIFF
--- a/array/sunro/n^2 배열 자르기.py
+++ b/array/sunro/n^2 배열 자르기.py
@@ -1,0 +1,15 @@
+def solution(n, left, right):
+    """
+    n: 배열의 크기 (n x n)
+    left, right: 평탄화된 1차원 배열에서 반환할 시작, 끝 인덱스 (inclusive)
+    """
+    answer = []
+
+    # left부터 right까지 하나씩 인덱스를 계산
+    for idx in range(left, right + 1):
+        row = idx // n  # 해당 인덱스의 행
+        col = idx % n  # 해당 인덱스의 열
+        value = max(row, col) + 1  # 규칙에 따른 값 계산
+        answer.append(value)
+
+    return answer

--- a/array/sunro/두_수의_합.py
+++ b/array/sunro/두_수의_합.py
@@ -1,0 +1,27 @@
+import sys
+
+def Main():
+    input = sys.stdin.readline
+    n = int(input().strip())
+    A = list(map(int, input().split()))
+    x = int(input().strip())
+
+    A.sort()
+
+    count = 0
+    left, right = 0, n - 1
+
+    while left < right:
+        current_sum = A[left] + A[right]
+        if current_sum == x:
+            count += 1
+            left += 1
+        elif current_sum < x:
+            left += 1
+        else:
+            right -= 1
+
+    print(count)
+
+if __name__ == "__main__":
+    Main()


### PR DESCRIPTION
## 문제 회고

### 문제 이해하기
- \( n \times n \) 크기의 2차원 배열이 있음.  
- 배열의 값은 **(행, 열)** 좌표를 기준으로 `max(row, col) + 1`로 채워짐.  
- 이 배열을 **1차원 배열로 평탄화**했을 때 `left` ~ `right` 구간의 값을 반환해야 함.
- 예를 들어 `n=3`, `left=2`, `right=5`라면:
  - 2차원 배열:
    ```
    [1,2,3]
    [2,2,3]
    [3,3,3]
    ```
  - 평탄화 배열:
    ```
    [1,2,3,2,2,3,3,3,3]
    ```
  - 결과:
    ```
    [3,2,2,3]
    ```

---

### 문제 접근 방법
1. 처음엔 **2차원 배열 전체를 생성**해서 평탄화 후 슬라이싱하려고 했지만,  
   \( n \)이 최대 \( 10^7 \)이라 **메모리 초과**가 발생할 수 있음을 파악함.
2. 1차원 인덱스를 기반으로 **행과 열을 직접 계산**하는 방법으로 접근:
   - `row = idx // n`
   - `col = idx % n`
   - `value = max(row, col) + 1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added capability to generate a segment of a conceptual n x n array without building the full matrix, improving performance for large inputs.
  - Introduced a command-line tool that reads a list of integers and a target, then reports the number of pairs that sum to the target using an efficient two-pointer approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->